### PR TITLE
fix: correct typos in schema definitions

### DIFF
--- a/release/yaml/crvs_api_v1.0.0.yaml
+++ b/release/yaml/crvs_api_v1.0.0.yaml
@@ -938,7 +938,7 @@ components:
                       3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
                         - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
                         - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-                    oneOf:
+                    anyOf:
                       - type: object
                         description: Identifier type and value object
                         properties:
@@ -1032,7 +1032,7 @@ components:
                                     - in
                                   example: eq
                                 attribute_value:
-                                  $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1/properties/value/allOf/1'
+                                  $ref: '#/components/schemas/SearchRequest/properties/search_request/items/properties/search_criteria/properties/query/anyOf/1/properties/value/allOf/1'
                               required:
                                 - attribute_name
                                 - operator
@@ -1046,7 +1046,7 @@ components:
                                 - not
                               example: and
                             expression2:
-                              $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2/items/properties/expression1'
+                              $ref: '#/components/schemas/SearchRequest/properties/search_request/items/properties/search_criteria/properties/query/anyOf/2/items/properties/expression1'
                           required:
                             - expression1
                   sort:
@@ -1421,7 +1421,7 @@ components:
                       3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
                         - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
                         - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-                    oneOf:
+                    anyOf:
                       - type: object
                         description: Identifier type and value object
                         properties:
@@ -1464,8 +1464,8 @@ components:
                                     }
                                   }
                                 }
-                      - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1'
-                      - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2'
+                      - $ref: '#/components/schemas/SearchRequest/properties/search_request/items/properties/search_criteria/properties/query/anyOf/1'
+                      - $ref: '#/components/schemas/SearchRequest/properties/search_request/items/properties/search_criteria/properties/query/anyOf/2'
                   notify_record_type:
                     type: string
                     description: |
@@ -1544,16 +1544,12 @@ components:
                       $ref: '#/components/schemas/SubscribeRequest/properties/subscribe_request/items/properties/subscribe_criteria/properties/filter'
                     notify_record_type:
                       $ref: '#/components/schemas/SubscribeRequest/properties/subscribe_request/items/properties/subscribe_criteria/properties/notify_record_type'
-                      required:
-                        - reg_event_type
-                        - filter
-                        - notify_record_type
                     locale:
                       $ref: '#/components/schemas/TxnStatusRequest/properties/txnstatus_request/properties/locale'
                   required:
-                    - subscription_code
+                    - code
+                    - status
                     - timestamp
-                    - subscribe_criteria
               pagination:
                 $ref: '#/components/schemas/SearchResponse/properties/search_response/items/properties/pagination'
               locale:
@@ -1605,7 +1601,7 @@ components:
                 - correlation_id
                 - subscription_code_list
             attribute_value:
-              oneOf:
+              anyOf:
                 - $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
                 - type: array
                   items:
@@ -1782,7 +1778,7 @@ components:
       properties:
         transaction_id:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
-        timesstamp:
+        timestamp:
           $ref: '#/components/schemas/MsgHeader_V1.0.0/properties/message_ts'
         subscription_codes:
           type: array
@@ -1795,7 +1791,7 @@ components:
       required:
         - transaction_id
         - timestamp
-        - sunscription_codes
+        - subscription_codes
     UnSubscribeResponse:
       type: object
       description: Un-Subscribe to a life event with crvs
@@ -1804,7 +1800,7 @@ components:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
         correlation_id:
           $ref: '#/components/schemas/SearchResponse/properties/correlation_id'
-        timesatmp:
+        timestamp:
           $ref: '#/components/schemas/MsgHeader_V1.0.0/properties/message_ts'
         status:
           type: string

--- a/release/yaml/crvs_api_v1.0.0.yaml
+++ b/release/yaml/crvs_api_v1.0.0.yaml
@@ -1637,9 +1637,9 @@ components:
               type: string
               description: txn type to fetch status
               enum:
-                - on-search
-                - on-subscribe
-                - on-unsubscribe
+                - search
+                - subscribe
+                - unsubscribe
             txn_status:
               oneOf:
                 - $ref: '#/components/schemas/TxnStatusResponse/properties/txnstatus_response/example'

--- a/release/yaml/dr_api_v1.0.0.yaml
+++ b/release/yaml/dr_api_v1.0.0.yaml
@@ -792,7 +792,7 @@ components:
       description: |
         1. Implementing systems can define schemas.
         2. Based on context, pre defined named queries can also help as part of ExpTemplate construct.
-      oneOf:
+      anyOf:
         - $ref: '#/components/schemas/ExpTemplate'
         - type: object
           description: Identifier type and value object
@@ -853,7 +853,7 @@ components:
                       - in
                     example: eq
                   attribute_value:
-                    $ref: '#/components/schemas/SubscriptionInfo/properties/filter/oneOf/1/properties/value/allOf/1'
+                    $ref: '#/components/schemas/RegistryQueries/anyOf/1/properties/value/allOf/1'
                 required:
                   - attribute_name
                   - operator
@@ -867,7 +867,7 @@ components:
                   - not
                 example: and
               expression2:
-                $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2/items/properties/expression1'
+                $ref: '#/components/schemas/RegistryQueries/anyOf/2/items/properties/expression1'
             required:
               - expression1
     NotifyEventRequest:
@@ -1297,16 +1297,12 @@ components:
                       $ref: '#/components/schemas/RegistryQueries'
                     notify_record_type:
                       $ref: '#/components/schemas/SearchResponse/properties/search_response/items/properties/data/properties/reg_record_type'
-                      required:
-                        - reg_event_type
-                        - filter
-                        - notify_record_type
                     locale:
                       $ref: '#/components/schemas/SubscriptionInfo/properties/locale'
                   required:
-                    - subscription_code
+                    - code
+                    - status
                     - timestamp
-                    - subscribe_criteria
               pagination:
                 $ref: '#/components/schemas/SearchResponse/properties/search_response/items/properties/pagination'
               locale:
@@ -1415,7 +1411,7 @@ components:
             3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
               - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
               - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-          oneOf:
+          anyOf:
             - type: object
               description: Identifier type and value object
               properties:
@@ -1458,13 +1454,9 @@ components:
                           }
                         }
                       }
-            - $ref: '#/components/schemas/RegistryQueries/oneOf/1'
-            - $ref: '#/components/schemas/RegistryQueries/oneOf/2'
+            - $ref: '#/components/schemas/RegistryQueries/anyOf/1'
+            - $ref: '#/components/schemas/RegistryQueries/anyOf/2'
         notify_record_type:
-          required:
-            - reg_event_type
-            - filter
-            - notify_record_type
           type: string
           description: |
             @context: https://schema.spdci.org/common/v1/api-schemas/RegistryRecordType.jsonld <br>
@@ -1482,9 +1474,9 @@ components:
           pattern: '^[a-z]{3,3}$'
           example: en
       required:
-        - subscription_code
+        - code
+        - status
         - timestamp
-        - subscribe_criteria
     SubscriptionStatus:
       type: string
       description: subscription status
@@ -1497,7 +1489,7 @@ components:
       properties:
         transaction_id:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
-        timesstamp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         subscription_codes:
           type: array
@@ -1506,7 +1498,7 @@ components:
       required:
         - transaction_id
         - timestamp
-        - sunscription_codes
+        - subscription_codes
     UnSubscribeResponse:
       type: object
       description: Un-Subscribe to a life event with crvs
@@ -1515,7 +1507,7 @@ components:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
         correlation_id:
           $ref: '#/components/schemas/SearchResponse/properties/correlation_id'
-        timesatmp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         status:
           type: string

--- a/release/yaml/fr_api_v1.0.0.yaml
+++ b/release/yaml/fr_api_v1.0.0.yaml
@@ -1656,9 +1656,9 @@ components:
               type: string
               description: txn type to fetch status
               enum:
-                - on-search
-                - on-subscribe
-                - on-unsubscribe
+                - search
+                - subscribe
+                - unsubscribe
             txn_status:
               oneOf:
                 - $ref: '#/components/schemas/TxnStatusResponse/properties/txnstatus_response/example'

--- a/release/yaml/fr_api_v1.0.0.yaml
+++ b/release/yaml/fr_api_v1.0.0.yaml
@@ -787,7 +787,14 @@ components:
                   reg_record_type:
                     $ref: '#/components/schemas/SearchResponse/properties/search_response/items/properties/data/properties/reg_record_type'
                   reg_records:
-                    $ref: '#/components/schemas/SearchResponse/properties/search_response/items/properties/data/properties/reg_records'
+                    type: object
+                    description: |
+                      The "group" object contains fields expected in response of search
+                      @context: https://schema.spdci.org/extensions/fr/v1/FRPerson.jsonld <br>
+                      @type: "FRPerson" <br>
+                      @container: "@set" <br> 
+                    example:
+                      $ref: '#/components/schemas/SearchResponse/properties/search_response/items/properties/data/properties/reg_records/items'
                 required:
                   - reg_record_type
                   - reg_records
@@ -842,7 +849,7 @@ components:
                     description: |
                       1. Implementing systems can define schemas.
                       2. Based on context, pre defined named queries can also help as part of ExpTemplate construct.
-                    oneOf:
+                    anyOf:
                       - type: object
                         description: Identifier type and value object
                         properties:
@@ -873,82 +880,8 @@ components:
                                         $eq: 9.56
                                     - farm_info.location.geo.longitude:
                                         $eq: 100.0245
-                      - type: object
-                        description: Identifier type and value object
-                        properties:
-                          type:
-                            type: string
-                            description: |
-                              @type: "IdType" <br>
-
-                              **Notes:**
-                                1. Identifier type values defined as per implementation context.
-                                2. Usually a list of **enum** values of all possible queryable identifiers.
-                                3. e.g: UIN, MOBILE, BRN, MRN, DRN, etc., 
-                            example: UIN
-                          value:
-                            allOf:
-                              - description: Identifier Value of the subject.
-                              - oneOf:
-                                  - type: string
-                                  - type: integer
-                                  - type: number
-                                  - type: boolean
-                                  - type: object
-                                example: '1980'
-                            example: '12314567890'
-                      - type: array
-                        items:
-                          type: object
-                          properties:
-                            seq_num:
-                              description: Sequence number to help define precedence for evaluating a list of expression Predicates
-                              type: number
-                              example: 1
-                            expression1:
-                              type: object
-                              description: Expression
-                              properties:
-                                attribute_name:
-                                  type: string
-                                  description: |
-                                    @context: https://schema.spdci.org/common/v1/api-schemas/QueryAttributes.jsonld <br>
-                                    @type: "QueryAttributes" <br>
-
-                                    **Notes:**
-                                      1. Query attribute names defined as per implementation context.
-                                      2. Usually a list of **enum** values of all possible queryable attribute names.
-                                      3. e.g: UIN, YOB, DOB, age, mobile, area-code, pin-code, etc.,
-                                  example: YOB
-                                operator:
-                                  type: string
-                                  description: Operator in an expression
-                                  enum:
-                                    - gt
-                                    - lt
-                                    - eq
-                                    - ge
-                                    - le
-                                    - in
-                                  example: eq
-                                attribute_value:
-                                  $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1/properties/value/allOf/1'
-                              required:
-                                - attribute_name
-                                - operator
-                                - attribute_value
-                            condition:
-                              type: string
-                              description: Condition in an expression
-                              enum:
-                                - and
-                                - or
-                                - not
-                              example: and
-                            expression2:
-                              $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2/items/properties/expression1'
-                          required:
-                            - expression1
+                      - $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/1'
+                      - $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/2'
                   sort:
                     type: array
                     items:
@@ -1099,13 +1032,13 @@ components:
                         4. example: "spdci-extensions-dci:Farmer" 
                     example: 'spdci-extensions-dci:Farmer'
                   reg_records:
-                    type: object
+                    type: array
                     description: |
-                      The "group" object contains fields expected in response of search
+                      The "Entity" object contains fields expected in response of search
                       @context: https://schema.spdci.org/extensions/fr/v1/FRPerson.jsonld <br>
                       @type: "FRPerson" <br>
-                      @container: "@set" <br> 
-                    example:
+                      @container: "@set" <br>
+                    items:
                       type: object
                       description: |
                         1. Attributes of a person to create fetch records, create verifiable credentials or use in search criteria.
@@ -1297,17 +1230,7 @@ components:
                   filter:
                     $ref: '#/components/schemas/SubscriptionInfo/properties/filter'
                   notify_record_type:
-                    type: string
-                    description: |
-                      @context: https://schema.spdci.org/common/v1/api-schemas/RegistryRecordType.jsonld <br>
-                      @type: "RegistryRecordType" <br>
-
-                      **Notes:**
-                        1. Registry record type values defined as per implementation context.
-                        2. Usually a list of **enum** values of all possible queryable result sets 
-                        3. Referenced in search_request and notify events
-                        4. example: "spdci-extensions-dci:Member" 
-                    example: 'spdci-extensions-dci:Member'
+                    $ref: '#/components/schemas/SubscriptionInfo/properties/notify_record_type'
                   authorize:
                     $ref: '#/components/schemas/SearchRequest/properties/search_request/items/properties/search_criteria/properties/authorize'
                 required:
@@ -1460,7 +1383,7 @@ components:
             3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
               - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
               - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-          oneOf:
+          anyOf:
             - type: object
               description: Identifier type and value object
               properties:
@@ -1503,23 +1426,103 @@ components:
                           }
                         }
                       }
-            - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1'
-            - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2'
+            - type: object
+              description: Identifier type and value object
+              properties:
+                type:
+                  type: string
+                  description: |
+                    @type: "IdType" <br>
+
+                    **Notes:**
+                      1. Identifier type values defined as per implementation context.
+                      2. Usually a list of **enum** values of all possible queryable identifiers.
+                      3. e.g: UIN, MOBILE, BRN, MRN, DRN, etc., 
+                  example: UIN
+                value:
+                  allOf:
+                    - description: Identifier Value of the subject.
+                    - oneOf:
+                        - type: string
+                        - type: integer
+                        - type: number
+                        - type: boolean
+                        - type: object
+                      example: '1980'
+                  example: '12314567890'
+            - type: array
+              items:
+                type: object
+                properties:
+                  seq_num:
+                    description: Sequence number to help define precedence for evaluating a list of expression Predicates
+                    type: number
+                    example: 1
+                  expression1:
+                    type: object
+                    description: Expression
+                    properties:
+                      attribute_name:
+                        type: string
+                        description: |
+                          @context: https://schema.spdci.org/common/v1/api-schemas/QueryAttributes.jsonld <br>
+                          @type: "QueryAttributes" <br>
+
+                          **Notes:**
+                            1. Query attribute names defined as per implementation context.
+                            2. Usually a list of **enum** values of all possible queryable attribute names.
+                            3. e.g: UIN, YOB, DOB, age, mobile, area-code, pin-code, etc.,
+                        example: YOB
+                      operator:
+                        type: string
+                        description: Operator in an expression
+                        enum:
+                          - gt
+                          - lt
+                          - eq
+                          - ge
+                          - le
+                          - in
+                        example: eq
+                      attribute_value:
+                        $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/1/properties/value/allOf/1'
+                    required:
+                      - attribute_name
+                      - operator
+                      - attribute_value
+                  condition:
+                    type: string
+                    description: Condition in an expression
+                    enum:
+                      - and
+                      - or
+                      - not
+                    example: and
+                  expression2:
+                    $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/2/items/properties/expression1'
+                required:
+                  - expression1
         notify_record_type:
-          $ref: '#/components/schemas/SubscribeRequest/properties/subscribe_request/items/properties/subscribe_criteria/properties/notify_record_type'
-          required:
-            - reg_event_type
-            - filter
-            - notify_record_type
+          type: string
+          description: |
+            @context: https://schema.spdci.org/common/v1/api-schemas/RegistryRecordType.jsonld <br>
+            @type: "RegistryRecordType" <br>
+
+            **Notes:**
+              1. Registry record type values defined as per implementation context.
+              2. Usually a list of **enum** values of all possible queryable result sets 
+              3. Referenced in search_request and notify events
+              4. example: "spdci-extensions-dci:Member" 
+          example: 'spdci-extensions-dci:Member'
         locale:
           type: string
           description: indicates language code. SPDCI Connect supports country codes as per ISO 639.3 standard
           pattern: '^[a-z]{3,3}$'
           example: en
       required:
-        - subscription_code
+        - code
+        - status
         - timestamp
-        - subscribe_criteria
     SubscriptionStatus:
       type: string
       description: subscription status
@@ -1532,7 +1535,7 @@ components:
       properties:
         transaction_id:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
-        timesstamp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         subscription_codes:
           type: array
@@ -1541,7 +1544,7 @@ components:
       required:
         - transaction_id
         - timestamp
-        - sunscription_codes
+        - subscription_codes
     UnSubscribeResponse:
       type: object
       description: Un-Subscribe to a life event with crvs
@@ -1550,7 +1553,7 @@ components:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
         correlation_id:
           $ref: '#/components/schemas/SearchResponse/properties/correlation_id'
-        timesatmp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         status:
           type: string
@@ -1621,7 +1624,7 @@ components:
                 - correlation_id
                 - subscription_code_list
             attribute_value:
-              oneOf:
+              anyOf:
                 - $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
                 - type: array
                   items:
@@ -1697,7 +1700,7 @@ components:
                         reg_type:
                           $ref: '#/components/schemas/SubscriptionInfo/properties/reg_type'
                         reg_record_type:
-                          $ref: '#/components/schemas/SubscribeRequest/properties/subscribe_request/items/properties/subscribe_criteria/properties/notify_record_type'
+                          $ref: '#/components/schemas/SubscriptionInfo/properties/notify_record_type'
                         reg_records:
                           type: object
                           description: |

--- a/release/yaml/ibr_api_v1.0.0.yaml
+++ b/release/yaml/ibr_api_v1.0.0.yaml
@@ -1119,7 +1119,7 @@ components:
                       3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
                         - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
                         - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-                    oneOf:
+                    anyOf:
                       - type: object
                         description: Identifier type and value object
                         properties:
@@ -1153,82 +1153,8 @@ components:
                                         $eq: central_region
                                     - group_size:
                                         $lt: 5
-                      - type: object
-                        description: Identifier type and value object
-                        properties:
-                          type:
-                            type: string
-                            description: |
-                              @type: "IdType" <br>
-
-                              **Notes:**
-                                1. Identifier type values defined as per implementation context.
-                                2. Usually a list of **enum** values of all possible queryable identifiers.
-                                3. e.g: UIN, MOBILE, BRN, MRN, DRN, etc., 
-                            example: UIN
-                          value:
-                            allOf:
-                              - description: Identifier Value of the subject.
-                              - oneOf:
-                                  - type: string
-                                  - type: integer
-                                  - type: number
-                                  - type: boolean
-                                  - type: object
-                                example: '1980'
-                            example: '12314567890'
-                      - type: array
-                        items:
-                          type: object
-                          properties:
-                            seq_num:
-                              description: Sequence number to help define precedence for evaluating a list of expression Predicates
-                              type: number
-                              example: 1
-                            expression1:
-                              type: object
-                              description: Expression
-                              properties:
-                                attribute_name:
-                                  type: string
-                                  description: |
-                                    @context: https://schema.spdci.org/common/v1/api-schemas/QueryAttributes.jsonld <br>
-                                    @type: "QueryAttributes" <br>
-
-                                    **Notes:**
-                                      1. Query attribute names defined as per implementation context.
-                                      2. Usually a list of **enum** values of all possible queryable attribute names.
-                                      3. e.g: UIN, YOB, DOB, age, mobile, area-code, pin-code, etc.,
-                                  example: YOB
-                                operator:
-                                  type: string
-                                  description: Operator in an expression
-                                  enum:
-                                    - gt
-                                    - lt
-                                    - eq
-                                    - ge
-                                    - le
-                                    - in
-                                  example: eq
-                                attribute_value:
-                                  $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1/properties/value/allOf/1'
-                              required:
-                                - attribute_name
-                                - operator
-                                - attribute_value
-                            condition:
-                              type: string
-                              description: Condition in an expression
-                              enum:
-                                - and
-                                - or
-                                - not
-                              example: and
-                            expression2:
-                              $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2/items/properties/expression1'
-                          required:
-                            - expression1
+                      - $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/1'
+                      - $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/2'
                   sort:
                     type: array
                     items:
@@ -1520,17 +1446,7 @@ components:
                   filter:
                     $ref: '#/components/schemas/SubscriptionInfo/properties/filter'
                   notify_record_type:
-                    type: string
-                    description: |
-                      @context: https://schema.spdci.org/common/v1/api-schemas/RegistryRecordType.jsonld <br>
-                      @type: "RegistryRecordType" <br>
-
-                      **Notes:**
-                        1. Registry record type values defined as per implementation context.
-                        2. Usually a list of **enum** values of all possible queryable result sets 
-                        3. Referenced in search_request and notify events
-                        4. example: "spdci-extensions-dci:Member" 
-                    example: 'spdci-extensions-dci:Member'
+                    $ref: '#/components/schemas/SubscriptionInfo/properties/notify_record_type'
                   authorize:
                     $ref: '#/components/schemas/SearchRequest/properties/search_request/items/properties/search_criteria/properties/authorize'
                 required:
@@ -1683,7 +1599,7 @@ components:
             3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
               - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
               - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-          oneOf:
+          anyOf:
             - type: object
               description: Identifier type and value object
               properties:
@@ -1726,23 +1642,103 @@ components:
                           }
                         }
                       }
-            - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1'
-            - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2'
+            - type: object
+              description: Identifier type and value object
+              properties:
+                type:
+                  type: string
+                  description: |
+                    @type: "IdType" <br>
+
+                    **Notes:**
+                      1. Identifier type values defined as per implementation context.
+                      2. Usually a list of **enum** values of all possible queryable identifiers.
+                      3. e.g: UIN, MOBILE, BRN, MRN, DRN, etc., 
+                  example: UIN
+                value:
+                  allOf:
+                    - description: Identifier Value of the subject.
+                    - oneOf:
+                        - type: string
+                        - type: integer
+                        - type: number
+                        - type: boolean
+                        - type: object
+                      example: '1980'
+                  example: '12314567890'
+            - type: array
+              items:
+                type: object
+                properties:
+                  seq_num:
+                    description: Sequence number to help define precedence for evaluating a list of expression Predicates
+                    type: number
+                    example: 1
+                  expression1:
+                    type: object
+                    description: Expression
+                    properties:
+                      attribute_name:
+                        type: string
+                        description: |
+                          @context: https://schema.spdci.org/common/v1/api-schemas/QueryAttributes.jsonld <br>
+                          @type: "QueryAttributes" <br>
+
+                          **Notes:**
+                            1. Query attribute names defined as per implementation context.
+                            2. Usually a list of **enum** values of all possible queryable attribute names.
+                            3. e.g: UIN, YOB, DOB, age, mobile, area-code, pin-code, etc.,
+                        example: YOB
+                      operator:
+                        type: string
+                        description: Operator in an expression
+                        enum:
+                          - gt
+                          - lt
+                          - eq
+                          - ge
+                          - le
+                          - in
+                        example: eq
+                      attribute_value:
+                        $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/1/properties/value/allOf/1'
+                    required:
+                      - attribute_name
+                      - operator
+                      - attribute_value
+                  condition:
+                    type: string
+                    description: Condition in an expression
+                    enum:
+                      - and
+                      - or
+                      - not
+                    example: and
+                  expression2:
+                    $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/2/items/properties/expression1'
+                required:
+                  - expression1
         notify_record_type:
-          $ref: '#/components/schemas/SubscribeRequest/properties/subscribe_request/items/properties/subscribe_criteria/properties/notify_record_type'
-          required:
-            - reg_event_type
-            - filter
-            - notify_record_type
+          type: string
+          description: |
+            @context: https://schema.spdci.org/common/v1/api-schemas/RegistryRecordType.jsonld <br>
+            @type: "RegistryRecordType" <br>
+
+            **Notes:**
+              1. Registry record type values defined as per implementation context.
+              2. Usually a list of **enum** values of all possible queryable result sets 
+              3. Referenced in search_request and notify events
+              4. example: "spdci-extensions-dci:Member" 
+          example: 'spdci-extensions-dci:Member'
         locale:
           type: string
           description: indicates language code. SPDCI Connect supports country codes as per ISO 639.3 standard
           pattern: '^[a-z]{3,3}$'
           example: en
       required:
-        - subscription_code
+        - code
+        - status
         - timestamp
-        - subscribe_criteria
     SubscriptionStatus:
       type: string
       description: subscription status
@@ -1755,7 +1751,7 @@ components:
       properties:
         transaction_id:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
-        timesstamp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         subscription_codes:
           type: array
@@ -1764,7 +1760,7 @@ components:
       required:
         - transaction_id
         - timestamp
-        - sunscription_codes
+        - subscription_codes
     UnSubscribeResponse:
       type: object
       description: Un-Subscribe to a life event with crvs
@@ -1773,7 +1769,7 @@ components:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
         correlation_id:
           $ref: '#/components/schemas/SearchResponse/properties/correlation_id'
-        timesatmp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         status:
           type: string
@@ -1834,7 +1830,7 @@ components:
               description: txn type to fetch status
               enum:
                 - search
-                - subscibe
+                - subscribe
                 - receipt
             attribute_type:
               type: string
@@ -1843,7 +1839,7 @@ components:
                 - reference_id_list
                 - correlation_id
             attribute_value:
-              oneOf:
+              anyOf:
                 - $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
                 - type: array
                   items:
@@ -1875,7 +1871,7 @@ components:
               description: txn type to fetch status
               enum:
                 - search
-                - subscibe
+                - subscribe
                 - receipt
             txn_status:
               oneOf:

--- a/release/yaml/social_api_v1.0.0.yaml
+++ b/release/yaml/social_api_v1.0.0.yaml
@@ -883,7 +883,7 @@ components:
                       3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
                         - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
                         - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-                    oneOf:
+                    anyOf:
                       - type: object
                         description: Identifier type and value object
                         properties:
@@ -917,82 +917,8 @@ components:
                                         $eq: central_region
                                     - group_size:
                                         $lt: 5
-                      - type: object
-                        description: Identifier type and value object
-                        properties:
-                          type:
-                            type: string
-                            description: |
-                              @type: "IdType" <br>
-
-                              **Notes:**
-                                1. Identifier type values defined as per implementation context.
-                                2. Usually a list of **enum** values of all possible queryable identifiers.
-                                3. e.g: UIN, MOBILE, BRN, MRN, DRN, etc., 
-                            example: UIN
-                          value:
-                            allOf:
-                              - description: Identifier Value of the subject.
-                              - oneOf:
-                                  - type: string
-                                  - type: integer
-                                  - type: number
-                                  - type: boolean
-                                  - type: object
-                                example: '1980'
-                            example: '12314567890'
-                      - type: array
-                        items:
-                          type: object
-                          properties:
-                            seq_num:
-                              description: Sequence number to help define precedence for evaluating a list of expression Predicates
-                              type: number
-                              example: 1
-                            expression1:
-                              type: object
-                              description: Expression
-                              properties:
-                                attribute_name:
-                                  type: string
-                                  description: |
-                                    @context: https://schema.spdci.org/common/v1/api-schemas/QueryAttributes.jsonld <br>
-                                    @type: "QueryAttributes" <br>
-
-                                    **Notes:**
-                                      1. Query attribute names defined as per implementation context.
-                                      2. Usually a list of **enum** values of all possible queryable attribute names.
-                                      3. e.g: UIN, YOB, DOB, age, mobile, area-code, pin-code, etc.,
-                                  example: YOB
-                                operator:
-                                  type: string
-                                  description: Operator in an expression
-                                  enum:
-                                    - gt
-                                    - lt
-                                    - eq
-                                    - ge
-                                    - le
-                                    - in
-                                  example: eq
-                                attribute_value:
-                                  $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1/properties/value/allOf/1'
-                              required:
-                                - attribute_name
-                                - operator
-                                - attribute_value
-                            condition:
-                              type: string
-                              description: Condition in an expression
-                              enum:
-                                - and
-                                - or
-                                - not
-                              example: and
-                            expression2:
-                              $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2/items/properties/expression1'
-                          required:
-                            - expression1
+                      - $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/1'
+                      - $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/2'
                   sort:
                     type: array
                     items:
@@ -1411,17 +1337,7 @@ components:
                   filter:
                     $ref: '#/components/schemas/SubscriptionInfo/properties/filter'
                   notify_record_type:
-                    type: string
-                    description: |
-                      @context: https://schema.spdci.org/common/v1/api-schemas/RegistryRecordType.jsonld <br>
-                      @type: "RegistryRecordType" <br>
-
-                      **Notes:**
-                        1. Registry record type values defined as per implementation context.
-                        2. Usually a list of **enum** values of all possible queryable result sets 
-                        3. Referenced in search_request and notify events
-                        4. example: "spdci-extensions-dci:Member" 
-                    example: 'spdci-extensions-dci:Member'
+                    $ref: '#/components/schemas/SubscriptionInfo/properties/notify_record_type'
                   authorize:
                     $ref: '#/components/schemas/SearchRequest/properties/search_request/items/properties/search_criteria/properties/authorize'
                 required:
@@ -1574,7 +1490,7 @@ components:
             3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
               - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
               - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-          oneOf:
+          anyOf:
             - type: object
               description: Identifier type and value object
               properties:
@@ -1617,23 +1533,103 @@ components:
                           }
                         }
                       }
-            - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/1'
-            - $ref: '#/paths/~1registry~1search/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/search_request/items/properties/search_criteria/properties/query/oneOf/2'
+            - type: object
+              description: Identifier type and value object
+              properties:
+                type:
+                  type: string
+                  description: |
+                    @type: "IdType" <br>
+
+                    **Notes:**
+                      1. Identifier type values defined as per implementation context.
+                      2. Usually a list of **enum** values of all possible queryable identifiers.
+                      3. e.g: UIN, MOBILE, BRN, MRN, DRN, etc., 
+                  example: UIN
+                value:
+                  allOf:
+                    - description: Identifier Value of the subject.
+                    - oneOf:
+                        - type: string
+                        - type: integer
+                        - type: number
+                        - type: boolean
+                        - type: object
+                      example: '1980'
+                  example: '12314567890'
+            - type: array
+              items:
+                type: object
+                properties:
+                  seq_num:
+                    description: Sequence number to help define precedence for evaluating a list of expression Predicates
+                    type: number
+                    example: 1
+                  expression1:
+                    type: object
+                    description: Expression
+                    properties:
+                      attribute_name:
+                        type: string
+                        description: |
+                          @context: https://schema.spdci.org/common/v1/api-schemas/QueryAttributes.jsonld <br>
+                          @type: "QueryAttributes" <br>
+
+                          **Notes:**
+                            1. Query attribute names defined as per implementation context.
+                            2. Usually a list of **enum** values of all possible queryable attribute names.
+                            3. e.g: UIN, YOB, DOB, age, mobile, area-code, pin-code, etc.,
+                        example: YOB
+                      operator:
+                        type: string
+                        description: Operator in an expression
+                        enum:
+                          - gt
+                          - lt
+                          - eq
+                          - ge
+                          - le
+                          - in
+                        example: eq
+                      attribute_value:
+                        $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/1/properties/value/allOf/1'
+                    required:
+                      - attribute_name
+                      - operator
+                      - attribute_value
+                  condition:
+                    type: string
+                    description: Condition in an expression
+                    enum:
+                      - and
+                      - or
+                      - not
+                    example: and
+                  expression2:
+                    $ref: '#/components/schemas/SubscriptionInfo/properties/filter/anyOf/2/items/properties/expression1'
+                required:
+                  - expression1
         notify_record_type:
-          $ref: '#/components/schemas/SubscribeRequest/properties/subscribe_request/items/properties/subscribe_criteria/properties/notify_record_type'
-          required:
-            - reg_event_type
-            - filter
-            - notify_record_type
+          type: string
+          description: |
+            @context: https://schema.spdci.org/common/v1/api-schemas/RegistryRecordType.jsonld <br>
+            @type: "RegistryRecordType" <br>
+
+            **Notes:**
+              1. Registry record type values defined as per implementation context.
+              2. Usually a list of **enum** values of all possible queryable result sets 
+              3. Referenced in search_request and notify events
+              4. example: "spdci-extensions-dci:Member" 
+          example: 'spdci-extensions-dci:Member'
         locale:
           type: string
           description: indicates language code. SPDCI Connect supports country codes as per ISO 639.3 standard
           pattern: '^[a-z]{3,3}$'
           example: en
       required:
-        - subscription_code
+        - code
+        - status
         - timestamp
-        - subscribe_criteria
     SubscriptionStatus:
       type: string
       description: subscription status
@@ -1646,7 +1642,7 @@ components:
       properties:
         transaction_id:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
-        timesstamp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         subscription_codes:
           type: array
@@ -1655,7 +1651,7 @@ components:
       required:
         - transaction_id
         - timestamp
-        - sunscription_codes
+        - subscription_codes
     UnSubscribeResponse:
       type: object
       description: Un-Subscribe to a life event with crvs
@@ -1664,7 +1660,7 @@ components:
           $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
         correlation_id:
           $ref: '#/components/schemas/SearchResponse/properties/correlation_id'
-        timesatmp:
+        timestamp:
           $ref: '#/components/schemas/SubscriptionInfo/properties/timestamp'
         status:
           type: string
@@ -1725,7 +1721,7 @@ components:
               description: txn type to fetch status
               enum:
                 - search
-                - subscibe
+                - subscribe
                 - receipt
             attribute_type:
               type: string
@@ -1734,7 +1730,7 @@ components:
                 - reference_id_list
                 - correlation_id
             attribute_value:
-              oneOf:
+              anyOf:
                 - $ref: '#/components/schemas/SearchRequest/properties/transaction_id'
                 - type: array
                   items:
@@ -1766,7 +1762,7 @@ components:
               description: txn type to fetch status
               enum:
                 - search
-                - subscibe
+                - subscribe
                 - receipt
             txn_status:
               oneOf:
@@ -1791,7 +1787,7 @@ components:
                             @context: https://schema.spdci.org/extensions/ibr/v1/Beneficiary.jsonld <br>
                             @type: "@context" <br>   
                           items:
-                            $ref: '#/paths/~1registry~1txn~1on-status/post/requestBody/content/application~1json/schema/properties/message/oneOf/0/properties/txnstatus_response/example/properties/search_response/items/properties/data/properties/reg_records/items'
+                            $ref: '#/components/schemas/TxnStatusResponse/properties/txnstatus_response/example/properties/search_response/items/properties/data/properties/reg_records/items'
                   required:
                     - transaction_id
                     - receipt_information

--- a/src/registry/crvs/RegistryQueries.yaml
+++ b/src/registry/crvs/RegistryQueries.yaml
@@ -4,7 +4,7 @@ description: |
   3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
     - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
     - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-oneOf:
+anyOf:
   - $ref: ../crvs/ExpTemplate.yaml
   - $ref: ../../common/schema/IdentifierTypeValue.yaml
   - $ref: ../../common/schema/ExpPredicateWithConditionList.yaml

--- a/src/registry/dr/RegistryQueries.yaml
+++ b/src/registry/dr/RegistryQueries.yaml
@@ -1,7 +1,7 @@
 description: |
   1. Implementing systems can define schemas.
   2. Based on context, pre defined named queries can also help as part of ExpTemplate construct.
-oneOf:
+anyOf:
   - $ref: ../dr/ExpTemplate.yaml
   - $ref: ../../common/schema/IdentifierTypeValue.yaml
   - $ref: ../../common/schema/ExpPredicateWithConditionList.yaml

--- a/src/registry/dr/SubscriptionInfo.yaml
+++ b/src/registry/dr/SubscriptionInfo.yaml
@@ -21,13 +21,9 @@ properties:
     $ref: RegistryQueries.yaml
   notify_record_type:
     $ref: RegistryRecordType.yaml
-    required: 
-      - reg_event_type
-      - filter
-      - notify_record_type
   locale:
     $ref: "../../common/schema/LanguageCode.yaml"
 required:
-  - subscription_code
+  - code
+  - status
   - timestamp
-  - subscribe_criteria

--- a/src/registry/fr/RegistryQueries.yaml
+++ b/src/registry/fr/RegistryQueries.yaml
@@ -1,7 +1,7 @@
 description: |
   1. Implementing systems can define schemas.
   2. Based on context, pre defined named queries can also help as part of ExpTemplate construct.
-oneOf:
+anyOf:
   - $ref: ../fr/ExpTemplate.yaml
   - $ref: ../../common/schema/IdentifierTypeValue.yaml
   - $ref: ../../common/schema/ExpPredicateWithConditionList.yaml

--- a/src/registry/fr/SearchResponse.yaml
+++ b/src/registry/fr/SearchResponse.yaml
@@ -35,7 +35,14 @@ properties:
             reg_record_type:
               $ref: RegistryRecordType.yaml    
             reg_records:
-              $ref: RegistryRecord.yaml
+              type: array
+              description: |
+                The "Entity" object contains fields expected in response of search
+                @context: https://schema.spdci.org/extensions/fr/v1/FRPerson.jsonld <br>
+                @type: "FRPerson" <br>
+                @container: "@set" <br>
+              items:
+                $ref: "../../extensions/fr/FRPerson.yaml"
           required: 
             - reg_record_type
             - reg_records

--- a/src/registry/ibr/RegistryQueries.yaml
+++ b/src/registry/ibr/RegistryQueries.yaml
@@ -4,7 +4,7 @@ description: |
   3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
     - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
     - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-oneOf:
+anyOf:
   - $ref: ../social/ExpTemplate.yaml
   - $ref: ../../common/schema/IdentifierTypeValue.yaml
   - $ref: ../../common/schema/ExpPredicateWithConditionList.yaml

--- a/src/registry/ibr/SubscriptionInfo.yaml
+++ b/src/registry/ibr/SubscriptionInfo.yaml
@@ -21,13 +21,9 @@ properties:
     $ref: ../schema/RegistryQueries.yaml
   notify_record_type:
     $ref: RegistryRecordType.yaml
-    required: 
-      - reg_event_type
-      - filter
-      - notify_record_type
   locale:
     $ref: "../../common/schema/LanguageCode.yaml"
 required:
-  - subscription_code
+  - code
+  - status
   - timestamp
-  - subscribe_criteria

--- a/src/registry/ibr/TxnStatusRequest.yaml
+++ b/src/registry/ibr/TxnStatusRequest.yaml
@@ -11,7 +11,7 @@ properties:
       txn_type:
         type: string
         description: txn type to fetch status 
-        enum: ["search","subscibe","receipt"]
+        enum: ["search","subscribe","receipt"]
       attribute_type:
         type: string
         enum:

--- a/src/registry/ibr/TxnStatusRequest.yaml
+++ b/src/registry/ibr/TxnStatusRequest.yaml
@@ -19,7 +19,7 @@ properties:
           - "reference_id_list"
           - "correlation_id"
       attribute_value:
-        oneOf:
+        anyOf:
           - $ref: ../../common/schema/TransactionId.yaml
           - $ref: ../../common/schema/ReferenceIdList.yaml
           - $ref: ../../common/schema/CorrelationId.yaml

--- a/src/registry/ibr/TxnStatusResponse.yaml
+++ b/src/registry/ibr/TxnStatusResponse.yaml
@@ -11,7 +11,7 @@ properties:
       txn_type:
         type: string
         description: txn type to fetch status 
-        enum: ["search","subscibe","receipt"]
+        enum: ["search","subscribe","receipt"]
       txn_status:
         oneOf:
           - $ref: SearchResponse.yaml

--- a/src/registry/schema/RegistryQueries.yaml
+++ b/src/registry/schema/RegistryQueries.yaml
@@ -4,7 +4,7 @@ description: |
   3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
     - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
     - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-oneOf:
+anyOf:
   - $ref: ../../common/schema/ExpTemplate.yaml
   - $ref: ../../common/schema/IdentifierTypeValue.yaml
   - $ref: ../../common/schema/ExpPredicateWithConditionList.yaml

--- a/src/registry/schema/SubscriptionInfo.yaml
+++ b/src/registry/schema/SubscriptionInfo.yaml
@@ -21,13 +21,9 @@ properties:
     $ref: RegistryQueries.yaml
   notify_record_type:
     $ref: RegistryRecordType.yaml
-    required: 
-      - reg_event_type
-      - filter
-      - notify_record_type
   locale:
     $ref: "../../common/schema/LanguageCode.yaml"
 required:
-  - subscription_code
+  - code
+  - status
   - timestamp
-  - subscribe_criteria

--- a/src/registry/schema/TxnStatusRequest.yaml
+++ b/src/registry/schema/TxnStatusRequest.yaml
@@ -20,7 +20,7 @@ properties:
           - "correlation_id"
           - "subscription_code_list"
       attribute_value:
-        oneOf:
+        anyOf:
           - $ref: ../../common/schema/TransactionId.yaml
           - $ref: ../../common/schema/ReferenceIdList.yaml
           - $ref: ../../common/schema/CorrelationId.yaml

--- a/src/registry/schema/TxnStatusResponse.yaml
+++ b/src/registry/schema/TxnStatusResponse.yaml
@@ -11,7 +11,7 @@ properties:
       txn_type:
         type: string
         description: txn type to fetch status 
-        enum: ["on-search", "on-subscribe", "on-unsubscribe"]
+        enum: ["search", "subscribe", "unsubscribe"]
       txn_status:
         oneOf:
           - $ref: SearchResponse.yaml

--- a/src/registry/schema/UnSubscribeRequest.yaml
+++ b/src/registry/schema/UnSubscribeRequest.yaml
@@ -3,7 +3,7 @@ description: Un-Subscribe to registred subscriptions
 properties:
   transaction_id: 
     $ref: ../../common/schema/TransactionId.yaml
-  timesstamp:
+  timestamp:
     $ref: ../../common/schema/DateTime.yaml
   subscription_codes:
     type: array
@@ -12,4 +12,4 @@ properties:
 required:
   - transaction_id
   - timestamp
-  - sunscription_codes
+  - subscription_codes

--- a/src/registry/schema/UnSubscribeResponse.yaml
+++ b/src/registry/schema/UnSubscribeResponse.yaml
@@ -5,7 +5,7 @@ properties:
     $ref: ../../common/schema/TransactionId.yaml
   correlation_id:
     $ref: ../../common/schema/CorrelationId.yaml
-  timesatmp:
+  timestamp:
     $ref: ../../common/schema/DateTime.yaml
   status:
     $ref: "../../common/schema/RequestStatus.yaml" 

--- a/src/registry/social/RegistryQueries.yaml
+++ b/src/registry/social/RegistryQueries.yaml
@@ -4,7 +4,7 @@ description: |
   3. ExpressionWithConditionList is simple generic search query construct to solve for majority of search conditons. few examples: <br>
     - search or subscribe to update events; e.g any updates in postal_code 12345 between 1/jan/2020 and 31/dec/2020
     - search or subscribe to birth, death events; e.g any new birth in postal_code 12345 after 1/jan/2023
-oneOf:
+anyOf:
   - $ref: ../social/ExpTemplate.yaml
   - $ref: ../../common/schema/IdentifierTypeValue.yaml
   - $ref: ../../common/schema/ExpPredicateWithConditionList.yaml

--- a/src/registry/social/TxnStatusRequest.yaml
+++ b/src/registry/social/TxnStatusRequest.yaml
@@ -11,7 +11,7 @@ properties:
       txn_type:
         type: string
         description: txn type to fetch status 
-        enum: ["search","subscibe","receipt"]
+        enum: ["search","subscribe","receipt"]
       attribute_type:
         type: string
         enum:

--- a/src/registry/social/TxnStatusRequest.yaml
+++ b/src/registry/social/TxnStatusRequest.yaml
@@ -19,7 +19,7 @@ properties:
           - "reference_id_list"
           - "correlation_id"
       attribute_value:
-        oneOf:
+        anyOf:
           - $ref: ../../common/schema/TransactionId.yaml
           - $ref: ../../common/schema/ReferenceIdList.yaml
           - $ref: ../../common/schema/CorrelationId.yaml


### PR DESCRIPTION
## Summary

This PR fixes typos and schema issues that cause validation failures when implementing compliant clients/servers.

## Changes

### Typo Fixes

| File | Property | Original | Fixed |
|------|----------|----------|-------|
| `src/registry/schema/UnSubscribeRequest.yaml` | property name | `timesstamp` | `timestamp` |
| `src/registry/schema/UnSubscribeRequest.yaml` | required field | `sunscription_codes` | `subscription_codes` |
| `src/registry/schema/UnSubscribeResponse.yaml` | property name | `timesatmp` | `timestamp` |
| `src/registry/social/TxnStatusRequest.yaml` | txn_type enum | `subscibe` | `subscribe` |
| `src/registry/ibr/TxnStatusRequest.yaml` | txn_type enum | `subscibe` | `subscribe` |
| `src/registry/ibr/TxnStatusResponse.yaml` | txn_type enum | `subscibe` | `subscribe` |

### SubscriptionInfo Schema Fixes

Fixed in `src/registry/schema/SubscriptionInfo.yaml`, `src/registry/ibr/SubscriptionInfo.yaml`, `src/registry/dr/SubscriptionInfo.yaml`:

| Issue | Original | Fixed |
|-------|----------|-------|
| Nested `required` block incorrectly placed under `notify_record_type.$ref` | `required: [reg_event_type, filter, notify_record_type]` nested under $ref | Removed (invalid OpenAPI structure) |
| Required field references non-existent property | `subscription_code` | `code` |
| Required field references non-existent property | `subscribe_criteria` | `status` |

### TxnStatusRequest Validation Fix

Fixed in `src/registry/schema/TxnStatusRequest.yaml`, `src/registry/social/TxnStatusRequest.yaml`, `src/registry/ibr/TxnStatusRequest.yaml`:

| Issue | Original | Fixed | Reason |
|-------|----------|-------|--------|
| `attribute_value` validation | `oneOf` | `anyOf` | `transaction_id` and `correlation_id` are structurally identical schemas, causing valid requests to fail `oneOf` validation. The `attribute_type` field serves as semantic discriminator. |

### TxnStatusResponse.txn_type Normalization

Fixed in `src/registry/schema/TxnStatusResponse.yaml`:

| Issue | Original | Fixed | Reason |
|-------|----------|-------|--------|
| Inconsistent `txn_type` enum | `["on-search", "on-subscribe", "on-unsubscribe"]` | `["search", "subscribe", "unsubscribe"]` | Matches TxnStatusRequest enum values and IBR/Social definitions |

### FR SearchResponse Fix

Fixed in `src/registry/fr/SearchResponse.yaml`:

| Issue | Original | Fixed | Reason |
|-------|----------|-------|--------|
| `reg_records` type | `$ref: RegistryRecord.yaml` (object) | `type: array` with items | Consistent with Social and CRVS specs |

### RegistryQueries oneOf to anyOf Fix

Fixed in all domain RegistryQueries.yaml files:
- `src/registry/schema/RegistryQueries.yaml`
- `src/registry/social/RegistryQueries.yaml`
- `src/registry/crvs/RegistryQueries.yaml`
- `src/registry/fr/RegistryQueries.yaml`
- `src/registry/ibr/RegistryQueries.yaml`
- `src/registry/dr/RegistryQueries.yaml`

| Issue | Original | Fixed | Reason |
|-------|----------|-------|--------|
| `filter` field validation | `oneOf` | `anyOf` | Valid queries may match multiple schema definitions (e.g., `ExpTemplate`, `IdentifierTypeValue`, `ExpPredicateWithConditionList`). Using `oneOf` causes ambiguous validation failures. |

## Related Issues

- Fixes #45 (RegistryQueries oneOf ambiguity)
- Fixes #46 (attribute_value oneOf validation)
- Fixes #47 (filter oneOf ambiguity)
- Fixes #50 (FR reg_records type)
- Fixes #51 (TxnStatusResponse.txn_type inconsistency)

## Testing

These changes were identified and validated through the [spdci-compliance](https://github.com/OpenSPP/spdci-compliance) test suite, which validates OpenAPI request/response payloads against the specifications.